### PR TITLE
chore: complete reqstool org migration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,4 +4,4 @@ image:https://img.shields.io/github/issues/reqstool/reqstool-java-annotations?st
 image:https://img.shields.io/badge/Java-21-brightgreen.svg?style=for-the-badge["JVM support", link="https://sdkman.io"]
 image:https://img.shields.io/github/license/reqstool/reqstool-java-annotations?style=for-the-badge&logo=opensourceinitiative["License", link="https://opensource.org/license/mit/"]
 image:https://img.shields.io/github/actions/workflow/status/reqstool/reqstool-java-annotations/build.yml?style=for-the-badge&logo=github["Build", link="https://github.com/reqstool/reqstool-java-annotations/actions/workflows/build.yml"]
-image:https://img.shields.io/badge/Documentation-blue?style=for-the-badge&link=docs["Static Badge", link="https://reqstool.github.io/reqstool-java-annotations/reqstool-java-annotations/0.1.0/index.html"]
+image:https://img.shields.io/badge/Documentation-blue?style=for-the-badge&link=docs["Static Badge", link="https://reqstool.github.io/reqstool-java-annotations/reqstool-java-annotations/1.0.0/index.html"]

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -2,6 +2,6 @@
 
 name: reqstool-java-annotations
 title: Reqstool Java Annotations
-version: 0.1.0
+version: 1.0.0
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -7,7 +7,7 @@ To add dependency using Maven, add the following to your `pom.xml`:
 <dependency>
 	<groupId>io.github.reqstool</groupId>
 	<artifactId>reqstool-java-annotations</artifactId>
-	<version>0.1.0</version>
+	<version>1.0.0</version>
 </dependency>
 ----
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.reqstool</groupId>
     <artifactId>reqstool-java-annotations</artifactId>
-    <version>0.1.0</version>
+    <version>1.0.0</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>


### PR DESCRIPTION
## Summary
Follow-up to #133 — completes the migration to the reqstool GitHub org.

## Changes
- Update all URLs from Luftfartsverket to reqstool org (pom.xml, antora-playbook.yml, schema URLs)
- Update developer info to Reqstool Contributors
- Remove `.claude/` from tracking and add to `.gitignore`
- Set version to 1.0.0

## Test Plan
- [x] All 6 tests passing
- [x] Build succeeds with no compilation warnings