### PR TITLE
chore: rename secrets in publish_maven.yml

### DIFF
--- a/.github/workflows/publish_maven.yml
+++ b/.github/workflows/publish_maven.yml
@@ -26,13 +26,13 @@ jobs:
           java-version: "21"
           distribution: "temurin"
           server-id: central
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
           gpg-private-key: ${{ secrets.REQSTOOL_PRIVATE_GPG_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          gpg-passphrase: REQSTOOL_PRIVATE_GPG_PASSPHRASE
       - name: Publish to the Maven Central Repository
         run: mvn clean deploy
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.REQSTOOL_PRIVATE_GPG_KEY_PASSPHRASE }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          REQSTOOL_PRIVATE_GPG_PASSPHRASE: ${{ secrets.REQSTOOL_PRIVATE_GPG_KEY_PASSPHRASE }}


### PR DESCRIPTION
## Summary
- Rename GPG secrets from `SYSDEV_` to `REQSTOOL_` prefix
- Rename Maven server username/password env vars to `MAVEN_CENTRAL_`