### PR TITLE
fix(ci): grant pull-requests: read to the semantic-PR check

### DIFF
--- a/.github/workflows/check-semantic-pr.yml
+++ b/.github/workflows/check-semantic-pr.yml
@@ -6,7 +6,9 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
-  contents: read
+  # The callee reads PR metadata to validate the title; contents is not enough,
+  # and a callee may not request more than it is granted.
+  pull-requests: read
 
 jobs:
   check:


### PR DESCRIPTION
ⓘ PR titles have not actually been validated in this repo for some time — this is the second half of the fix.

## What & Why

The workflow granted `contents: read`, but `common-check-semantic-pr.yml` needs **`pull-requests: read`** to inspect the PR title. A callee may not request more than it is granted, so the run is rejected before any job starts.

Two separate bugs stacked here:

1. The reference pointed at a commit SHA that **predated the workflow file** (from before the `common-` rename), so it resolved to nothing. Fixed in the release-flow PR.
2. Even once it resolved, the permission was wrong. Fixed here.

Between the two, PR-title validation has been silently dead. As always with this failure mode: a startup failure produces **no check run**, so it never appeared in the checks list.

Found by an org-wide caller/callee permission audit.

## Author checklist

- [x] `actionlint` clean
- [x] Conventional Commit title, DCO sign-off

## Test Plan

This PR itself exercises it — `Check Semantic PR` should now run and pass rather than startup-fail. Note the `pull_request_target` leg reads the workflow from the **base** branch, so that leg only turns green after merge.